### PR TITLE
chore: ビルドスクリプトの実行警告を解消

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+onlyBuiltDependencies:
+  - '@nestjs/core'
+  - '@openapitools/openapi-generator-cli'
+  - '@parcel/watcher'
+  - '@swc/core'
+  - esbuild


### PR DESCRIPTION
## Summary

pnpm v9以降で発生するビルドスクリプトの実行警告を解消するため、`onlyBuiltDependencies` の設定を追加しました。

## Changes

- `pnpm approve-builds` コマンドを実行し、`pnpm-workspace.yaml` を生成
- 以下のパッケージのビルドスクリプト実行を許可:
  - `@nestjs/core`
  - `@openapitools/openapi-generator-cli`
  - `@parcel/watcher`
  - `@swc/core`
  - `esbuild`
  
## Verification

- ローカル環境で `pnpm i` を実行し、"Ignored build scripts" の警告が表示されなくなったことを確認済み

---

Closes #74