### PR TITLE
chore: pnpm dev opens /sandbox by default, while pnpm preview (the built version) defaults to / (Home).

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,4 +12,10 @@ export default defineConfig({
             "/@": path.resolve(__dirname, "src"),
         },
     },
+    server: {
+        open: "/sandbox",
+    },
+    preview: {
+        open: "/",
+    },
 });


### PR DESCRIPTION
開発環境のみ開いた時のデフォルトを、sandboxに。

---
Closes #82