### PR TITLE
feat: Remove `/api` prefix from internal API routes and add `VITE_USE…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
+        "dev:api": "VITE_USE_MOCK=false vite",
         "build": "tsc -b && vite build",
         "preview": "vite preview",
         "preview:with-build": "npm run build && npm run preview",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,17 +5,13 @@ import { Api as TraqApiClient } from "./schema/traq";
 export * from "./paths";
 
 // 環境変数からAPIのbaseURLを取得
-// 設定されていれば使用、なければspecのデフォルト値を使用
+// 設定されていれば使用、なければ空文字列（specのデフォルト + ローカルproxy）
 // 例: VITE_API_BASE_URL=https://pteron-api.trap.show
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
-
-// 環境変数があれば上書き、なければ空オブジェクト（specのデフォルト値を使用）
-const internalConfig = apiBaseUrl ? { baseURL: `${apiBaseUrl}/internal` } : {};
-const publicConfig = apiBaseUrl ? { baseURL: `${apiBaseUrl}/v1` } : {};
+const baseUrl = import.meta.env.VITE_API_BASE_URL ?? "";
 
 const apis = {
-    internal: new InternalApiClient(internalConfig),
-    public: new PublicApiClient(publicConfig),
+    internal: new InternalApiClient({ baseURL: `${baseUrl}/internal` }),
+    public: new PublicApiClient({ baseURL: `${baseUrl}/v1` }),
     traq: new TraqApiClient({}),
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,15 +1,22 @@
-import { type ApiConfig, Api as InternalApiClient } from "./schema/internal";
+import { Api as InternalApiClient } from "./schema/internal";
 import { Api as PublicApiClient } from "./schema/public";
 import { Api as TraqApiClient } from "./schema/traq";
 
 export * from "./paths";
 
-const config: ApiConfig = {};
+// 環境変数からAPIのbaseURLを取得
+// 設定されていれば使用、なければspecのデフォルト値を使用
+// 例: VITE_API_BASE_URL=https://pteron-api.trap.show
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+
+// 環境変数があれば上書き、なければ空オブジェクト（specのデフォルト値を使用）
+const internalConfig = apiBaseUrl ? { baseURL: `${apiBaseUrl}/internal` } : {};
+const publicConfig = apiBaseUrl ? { baseURL: `${apiBaseUrl}/v1` } : {};
 
 const apis = {
-    internal: new InternalApiClient(config),
-    public: new PublicApiClient(config),
-    traq: new TraqApiClient(config),
+    internal: new InternalApiClient(internalConfig),
+    public: new PublicApiClient(publicConfig),
+    traq: new TraqApiClient({}),
 };
 
 export default apis;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,11 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 
 async function enableMocking() {
-    if (import.meta.env.DEV) {
+    // VITE_USE_MOCK が "false" の場合はMSWを無効化
+    // 未設定 または "true" の場合は開発環境でMSWを有効化
+    const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+
+    if (import.meta.env.DEV && useMock) {
         const { worker } = await import("./mocks/browser");
         return worker.start({
             onUnhandledRequest: "bypass",

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -25,13 +25,13 @@ import {
 
 // ========== Internal API ハンドラー ==========
 const internalHandlers = [
-    // GET /api/internal/me - 自分の情報を取得
-    http.get("/api/internal/me", () => {
+    // GET /internal/me - 自分の情報を取得
+    http.get("/internal/me", () => {
         return HttpResponse.json(mockCurrentUser);
     }),
 
-    // GET /api/internal/me/bills/:bill_id - 請求の詳細を取得
-    http.get("/api/internal/me/bills/:bill_id", ({ params }) => {
+    // GET /internal/me/bills/:bill_id - 請求の詳細を取得
+    http.get("/internal/me/bills/:bill_id", ({ params }) => {
         const bill = getBillById(params.bill_id as string);
         if (!bill) {
             return new HttpResponse(null, { status: 404 });
@@ -39,8 +39,8 @@ const internalHandlers = [
         return HttpResponse.json(bill);
     }),
 
-    // POST /api/internal/me/bills/:bill_id/approve - 請求を承認
-    http.post("/api/internal/me/bills/:bill_id/approve", ({ params }) => {
+    // POST /internal/me/bills/:bill_id/approve - 請求を承認
+    http.post("/internal/me/bills/:bill_id/approve", ({ params }) => {
         const bill = getBillById(params.bill_id as string);
         if (!bill) {
             return new HttpResponse(null, { status: 404 });
@@ -54,8 +54,8 @@ const internalHandlers = [
         });
     }),
 
-    // POST /api/internal/me/bills/:bill_id/decline - 請求を拒否
-    http.post("/api/internal/me/bills/:bill_id/decline", ({ params }) => {
+    // POST /internal/me/bills/:bill_id/decline - 請求を拒否
+    http.post("/internal/me/bills/:bill_id/decline", ({ params }) => {
         const bill = getBillById(params.bill_id as string);
         if (!bill) {
             return new HttpResponse(null, { status: 404 });
@@ -66,8 +66,8 @@ const internalHandlers = [
         return new HttpResponse(null, { status: 204 });
     }),
 
-    // GET /api/internal/transactions - 経済圏全体の取引履歴
-    http.get("/api/internal/transactions", ({ request }) => {
+    // GET /internal/transactions - 経済圏全体の取引履歴
+    http.get("/internal/transactions", ({ request }) => {
         const url = new URL(request.url);
         const limit = Number(url.searchParams.get("limit")) || 20;
         const cursor = url.searchParams.get("cursor");
@@ -92,8 +92,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/transactions/users/:user_id - ユーザーの取引履歴
-    http.get("/api/internal/transactions/users/:user_id", ({ request, params }) => {
+    // GET /internal/transactions/users/:user_id - ユーザーの取引履歴
+    http.get("/internal/transactions/users/:user_id", ({ request, params }) => {
         const url = new URL(request.url);
         const limit = Number(url.searchParams.get("limit")) || 20;
         const userId = params.user_id as string;
@@ -107,8 +107,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/transactions/projects/:project_id - プロジェクトの取引履歴
-    http.get("/api/internal/transactions/projects/:project_id", ({ request, params }) => {
+    // GET /internal/transactions/projects/:project_id - プロジェクトの取引履歴
+    http.get("/internal/transactions/projects/:project_id", ({ request, params }) => {
         const url = new URL(request.url);
         const limit = Number(url.searchParams.get("limit")) || 20;
         const projectId = params.project_id as string;
@@ -122,8 +122,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/stats - 経済圏全体の統計情報
-    http.get("/api/internal/stats", () => {
+    // GET /internal/stats - 経済圏全体の統計情報
+    http.get("/internal/stats", () => {
         const totalBalance =
             mockUsers.reduce((sum, u) => sum + (u.balance ?? 0), 0) +
             mockProjects.reduce((sum, p) => sum + (p.balance ?? 0), 0);
@@ -136,8 +136,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/stats/users - ユーザー関連統計
-    http.get("/api/internal/stats/users", () => {
+    // GET /internal/stats/users - ユーザー関連統計
+    http.get("/internal/stats/users", () => {
         const userBalance = mockUsers.reduce((sum, u) => sum + (u.balance ?? 0), 0);
         const userTransactions = mockTransactions.filter(t => t.type === "TRANSFER");
         return HttpResponse.json({
@@ -150,8 +150,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/stats/projects - プロジェクト関連統計
-    http.get("/api/internal/stats/projects", () => {
+    // GET /internal/stats/projects - プロジェクト関連統計
+    http.get("/internal/stats/projects", () => {
         const projectBalance = mockProjects.reduce((sum, p) => sum + (p.balance ?? 0), 0);
         return HttpResponse.json({
             number: mockProjects.length,
@@ -163,8 +163,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/stats/users/:ranking_name - ユーザーランキング
-    http.get("/api/internal/stats/users/:ranking_name", ({ request }) => {
+    // GET /internal/stats/users/:ranking_name - ユーザーランキング
+    http.get("/internal/stats/users/:ranking_name", ({ request }) => {
         const url = new URL(request.url);
         const limit = Number(url.searchParams.get("limit")) || 20;
         const order = url.searchParams.get("order") || "desc";
@@ -187,8 +187,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/stats/projects/:project_name - プロジェクトランキング
-    http.get("/api/internal/stats/projects/:project_name", ({ request }) => {
+    // GET /internal/stats/projects/:project_name - プロジェクトランキング
+    http.get("/internal/stats/projects/:project_name", ({ request }) => {
         const url = new URL(request.url);
         const limit = Number(url.searchParams.get("limit")) || 20;
         const order = url.searchParams.get("order") || "desc";
@@ -211,8 +211,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/users - 全ユーザー一覧
-    http.get("/api/internal/users", ({ request }) => {
+    // GET /internal/users - 全ユーザー一覧
+    http.get("/internal/users", ({ request }) => {
         const url = new URL(request.url);
         const limit = Number(url.searchParams.get("limit")) || 20;
         const cursor = url.searchParams.get("cursor");
@@ -235,8 +235,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/users/:user_id - ユーザー詳細
-    http.get("/api/internal/users/:user_id", ({ params }) => {
+    // GET /internal/users/:user_id - ユーザー詳細
+    http.get("/internal/users/:user_id", ({ params }) => {
         const user = getUserByIdOrName(params.user_id as string);
         if (!user) {
             return new HttpResponse(null, { status: 404 });
@@ -244,8 +244,8 @@ const internalHandlers = [
         return HttpResponse.json(user);
     }),
 
-    // GET /api/internal/users/:user_id/balance - ユーザー残高
-    http.get("/api/internal/users/:user_id/balance", ({ params }) => {
+    // GET /internal/users/:user_id/balance - ユーザー残高
+    http.get("/internal/users/:user_id/balance", ({ params }) => {
         const user = getUserByIdOrName(params.user_id as string);
         if (!user) {
             return new HttpResponse(null, { status: 404 });
@@ -255,8 +255,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/users/:user_id/stats - ユーザーのランキング順位一覧
-    http.get("/api/internal/users/:user_id/stats", ({ params }) => {
+    // GET /internal/users/:user_id/stats - ユーザーのランキング順位一覧
+    http.get("/internal/users/:user_id/stats", ({ params }) => {
         const user = getUserByIdOrName(params.user_id as string);
         if (!user) {
             return new HttpResponse(null, { status: 404 });
@@ -283,15 +283,15 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/users/:user_id/projects - ユーザーのプロジェクト一覧
-    http.get("/api/internal/users/:user_id/projects", ({ params }) => {
+    // GET /internal/users/:user_id/projects - ユーザーのプロジェクト一覧
+    http.get("/internal/users/:user_id/projects", ({ params }) => {
         const userId = params.user_id as string;
         const userProjects = getProjectsByOwnerOrAdminIdOrName(userId);
         return HttpResponse.json(userProjects);
     }),
 
-    // GET /api/internal/projects - 全プロジェクト一覧
-    http.get("/api/internal/projects", ({ request }) => {
+    // GET /internal/projects - 全プロジェクト一覧
+    http.get("/internal/projects", ({ request }) => {
         const url = new URL(request.url);
         const limit = Number(url.searchParams.get("limit")) || 20;
         const cursor = url.searchParams.get("cursor");
@@ -316,8 +316,8 @@ const internalHandlers = [
         });
     }),
 
-    // POST /api/internal/projects - プロジェクト新規作成
-    http.post("/api/internal/projects", async ({ request }) => {
+    // POST /internal/projects - プロジェクト新規作成
+    http.post("/internal/projects", async ({ request }) => {
         const body = (await request.json()) as { name?: string; url?: string };
         const newProject = {
             id: generateUUID(),
@@ -330,8 +330,8 @@ const internalHandlers = [
         return HttpResponse.json(newProject, { status: 201 });
     }),
 
-    // GET /api/internal/projects/:project_id - プロジェクト詳細
-    http.get("/api/internal/projects/:project_id", ({ params }) => {
+    // GET /internal/projects/:project_id - プロジェクト詳細
+    http.get("/internal/projects/:project_id", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -339,8 +339,8 @@ const internalHandlers = [
         return HttpResponse.json(project);
     }),
 
-    // PUT /api/internal/projects/:project_id - プロジェクト更新
-    http.put("/api/internal/projects/:project_id", async ({ params, request }) => {
+    // PUT /internal/projects/:project_id - プロジェクト更新
+    http.put("/internal/projects/:project_id", async ({ params, request }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -355,8 +355,8 @@ const internalHandlers = [
         );
     }),
 
-    // GET /api/internal/projects/:project_id/balance - プロジェクト残高
-    http.get("/api/internal/projects/:project_id/balance", ({ params }) => {
+    // GET /internal/projects/:project_id/balance - プロジェクト残高
+    http.get("/internal/projects/:project_id/balance", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -366,8 +366,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/projects/:project_id/stats - プロジェクトのランキング順位一覧
-    http.get("/api/internal/projects/:project_id/stats", ({ params }) => {
+    // GET /internal/projects/:project_id/stats - プロジェクトのランキング順位一覧
+    http.get("/internal/projects/:project_id/stats", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -396,8 +396,8 @@ const internalHandlers = [
         });
     }),
 
-    // GET /api/internal/projects/:project_id/admins - 管理者一覧
-    http.get("/api/internal/projects/:project_id/admins", ({ params }) => {
+    // GET /internal/projects/:project_id/admins - 管理者一覧
+    http.get("/internal/projects/:project_id/admins", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -405,8 +405,8 @@ const internalHandlers = [
         return HttpResponse.json(project.admins ?? []);
     }),
 
-    // POST /api/internal/projects/:project_id/admins - 管理者追加
-    http.post("/api/internal/projects/:project_id/admins", ({ params }) => {
+    // POST /internal/projects/:project_id/admins - 管理者追加
+    http.post("/internal/projects/:project_id/admins", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -414,8 +414,8 @@ const internalHandlers = [
         return new HttpResponse(null, { status: 204 });
     }),
 
-    // DELETE /api/internal/projects/:project_id/admins - 管理者削除
-    http.delete("/api/internal/projects/:project_id/admins", ({ params }) => {
+    // DELETE /internal/projects/:project_id/admins - 管理者削除
+    http.delete("/internal/projects/:project_id/admins", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -423,8 +423,8 @@ const internalHandlers = [
         return new HttpResponse(null, { status: 204 });
     }),
 
-    // GET /api/internal/projects/:project_id/clients - APIクライアント一覧
-    http.get("/api/internal/projects/:project_id/clients", ({ params }) => {
+    // GET /internal/projects/:project_id/clients - APIクライアント一覧
+    http.get("/internal/projects/:project_id/clients", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -432,8 +432,8 @@ const internalHandlers = [
         return HttpResponse.json(mockAPIClients);
     }),
 
-    // POST /api/internal/projects/:project_id/clients - APIクライアント発行
-    http.post("/api/internal/projects/:project_id/clients", ({ params }) => {
+    // POST /internal/projects/:project_id/clients - APIクライアント発行
+    http.post("/internal/projects/:project_id/clients", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -446,8 +446,8 @@ const internalHandlers = [
         return HttpResponse.json(newClient, { status: 201 });
     }),
 
-    // DELETE /api/internal/projects/:project_id/clients/:client_id - APIクライアント削除
-    http.delete("/api/internal/projects/:project_id/clients/:client_id", ({ params }) => {
+    // DELETE /internal/projects/:project_id/clients/:client_id - APIクライアント削除
+    http.delete("/internal/projects/:project_id/clients/:client_id", ({ params }) => {
         const project = getProjectByIdOrName(params.project_id as string);
         if (!project) {
             return new HttpResponse(null, { status: 404 });
@@ -458,13 +458,13 @@ const internalHandlers = [
 
 // ========== Public API ハンドラー ==========
 const publicHandlers = [
-    // GET /api/v1/project - 自プロジェクト情報
-    http.get("/api/v1/project", () => {
+    // GET /v1/project - 自プロジェクト情報
+    http.get("/v1/project", () => {
         return HttpResponse.json(mockPublicProject);
     }),
 
-    // GET /api/v1/project/transactions - 取引履歴
-    http.get("/api/v1/project/transactions", ({ request }) => {
+    // GET /v1/project/transactions - 取引履歴
+    http.get("/v1/project/transactions", ({ request }) => {
         const url = new URL(request.url);
         const limit = Number(url.searchParams.get("limit")) || 20;
 
@@ -475,8 +475,8 @@ const publicHandlers = [
         });
     }),
 
-    // POST /api/v1/transactions - ユーザーへ送金
-    http.post("/api/v1/transactions", async ({ request }) => {
+    // POST /v1/transactions - ユーザーへ送金
+    http.post("/v1/transactions", async ({ request }) => {
         const body = (await request.json()) as {
             to_user: string;
             amount: number;
@@ -503,8 +503,8 @@ const publicHandlers = [
         return HttpResponse.json(transaction);
     }),
 
-    // POST /api/v1/bills - 請求作成
-    http.post("/api/v1/bills", async ({ request }) => {
+    // POST /v1/bills - 請求作成
+    http.post("/v1/bills", async ({ request }) => {
         const body = (await request.json()) as {
             target_user: string;
             amount: number;
@@ -529,8 +529,8 @@ const publicHandlers = [
         );
     }),
 
-    // GET /api/v1/bills/:bill_id - 請求ステータス
-    http.get("/api/v1/bills/:bill_id", ({ params }) => {
+    // GET /v1/bills/:bill_id - 請求ステータス
+    http.get("/v1/bills/:bill_id", ({ params }) => {
         const bill = mockPublicBills.find(b => b.id === params.bill_id);
         if (!bill) {
             return new HttpResponse(null, { status: 404 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,18 @@ export default defineConfig({
     },
     server: {
         open: "/sandbox",
+        // MSW無効時 (VITE_USE_MOCK=false) に実APIへ転送
+        proxy: {
+            "/internal": "http://localhost:8080",
+            "/v1": "http://localhost:8080",
+        },
     },
     preview: {
         open: "/",
+        // preview時はステージングAPIに接続
+        proxy: {
+            "/internal": "https://pteron-api-dev.trap.show",
+            "/v1": "https://pteron-api-dev.trap.show",
+        },
     },
 });


### PR DESCRIPTION

## 1. ローカル開発環境

| コマンド | 接続先API | 認証/DB | 用途 |
| --- | --- | --- | --- |
| `pnpm dev` | **Mock (MSW)** | なし | UI開発、単体での挙動確認 |
| `pnpm dev:api` | **localhost:8080** | ローカルDB | バックエンドとの結合テスト |
| `pnpm preview` | **https://pteron-api-dev...** | ステージングDB | ビルド成果物（Production相当）の確認 |

## 2. NeoShowcase環境設定

### A. 本番環境 (pteron)

* **接続先:** 本番APIサーバー
* **設定値:**
```bash
VITE_API_BASE_URL=https://pteron-api.trap.show
```

### B. ステージング環境 (dev-pteron)

* **接続先:** ステージングAPIサーバー
* **設定値:**
```bash
VITE_API_BASE_URL=https://pteron-api-dev.trap.show
```


---
Closes #113