### PR TITLE
feat: ローカルでも本番サーバーにつながるようにした

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,23 @@
+# ローカル開発環境での認証設定
+# このファイルを .env.local にコピーして使用してください
+# cp .env.local.example .env.local
+
+# ============================================================
+# X-Forwarded-User ヘッダー付与（ローカルサーバー接続時）
+# ============================================================
+# ローカルで起動したサーバー（DEBUG_MODE=true）に接続する際に使用
+# pnpm dev で VITE_USE_MOCK=false にした場合に有効
+#
+# DEV_USER=your_trap_id
+
+# ============================================================
+# Traefik認証クッキー転送（本番API接続時）
+# ============================================================
+# pnpm preview で本番API (pteron.trap.show) に接続する際に必要
+#
+# 取得方法:
+# 1. ブラウザで https://pteron.trap.show/api/internal/me にアクセスする
+# 2. ブラウザの開発者ツール → Application → Cookies
+# 3. _forward_auth クッキーの値をコピーする
+#
+# FORWARD_AUTH_COOKIE=your_cookie_value_here

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,31 +1,62 @@
 import path from "node:path";
 
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import svgr from "vite-plugin-svgr";
 
 // https://vite.dev/config/
-export default defineConfig({
-    plugins: [react(), svgr()],
-    resolve: {
-        alias: {
-            "/@": path.resolve(__dirname, "src"),
+export default defineConfig(({ mode }) => {
+    const env = loadEnv(mode, process.cwd(), "");
+
+    // プロキシ用のヘッダー設定
+    const proxyHeaders: Record<string, string> = {};
+
+    // DEV_USER: X-Forwarded-User ヘッダーを付与（ローカルサーバーのDEBUG_MODE時に使用）
+    if (env.DEV_USER) {
+        proxyHeaders["X-Forwarded-User"] = env.DEV_USER;
+    }
+
+    // FORWARD_AUTH_COOKIE: 本番API接続時のTraefik認証用クッキーを転送
+    if (env.FORWARD_AUTH_COOKIE) {
+        proxyHeaders["Cookie"] = `_forward_auth=${env.FORWARD_AUTH_COOKIE}`;
+    }
+
+    return {
+        plugins: [react(), svgr()],
+        resolve: {
+            alias: {
+                "/@": path.resolve(__dirname, "src"),
+            },
         },
-    },
-    server: {
-        open: "/sandbox",
-        // MSW無効時 (VITE_USE_MOCK=false) に実APIへ転送
-        proxy: {
-            "/api/internal": "http://localhost:8080",
-            "/api/v1": "http://localhost:8080",
+        server: {
+            open: "/sandbox",
+            // MSW無効時 (VITE_USE_MOCK=false) に実APIへ転送
+            proxy: {
+                "/api/internal": {
+                    target: "http://localhost:8080",
+                    headers: proxyHeaders,
+                },
+                "/api/v1": {
+                    target: "http://localhost:8080",
+                    headers: proxyHeaders,
+                },
+            },
         },
-    },
-    preview: {
-        open: "/",
-        // preview時はステージングAPIに接続
-        proxy: {
-            "/api/internal": "https://pteron-api-dev.trap.show",
-            "/api/v1": "https://pteron-api-dev.trap.show",
+        preview: {
+            open: "/",
+            // preview時は本番APIに接続
+            proxy: {
+                "/api/internal": {
+                    target: "https://pteron.trap.show",
+                    changeOrigin: true,
+                    headers: proxyHeaders,
+                },
+                "/api/v1": {
+                    target: "https://pteron.trap.show",
+                    changeOrigin: true,
+                    headers: proxyHeaders,
+                },
+            },
         },
-    },
+    };
 });


### PR DESCRIPTION
認証設定の使い方

- .env.local （.env.local.example をコピーして作成）に以下を設定します：
  DEV_USER: ローカルサーバー接続時のユーザー名（X-Forwarded-User ヘッダーになります）
  FORWARD_AUTH_COOKIE: 本番API接続時の _forward_auth クッキーの値
  
  
- pnpm buildした後、pnpm preview で本番API (pteron.trap.show) に接続し、設定したクッキーを使って認証が行われます。

---
Closes #143