### PR TITLE
feat: pamountの省略表示を適応しました

### DIFF
--- a/src/components/EntityCard.tsx
+++ b/src/components/EntityCard.tsx
@@ -79,6 +79,7 @@ export const EntityCard = <Type extends EntityType>(_props: EntityCardProps<Type
                             value={amount}
                             leadingIcon
                             coloring
+                            compact
                         />
                     </Flex>
                 </Group>

--- a/src/components/TransactionItem.tsx
+++ b/src/components/TransactionItem.tsx
@@ -31,11 +31,11 @@ export const TransactionItem = ({ transaction, direction = "both" }: Transaction
     };
 
     const getProjectName = () => {
-        return toBranded<ProjectName>(transaction.project.name);
+        return toBranded<ProjectName>(transaction.project?.name ?? "");
     };
 
     const getUserName = () => {
-        return toBranded<UserName>(transaction.user.name);
+        return toBranded<UserName>(transaction.user?.name ?? "");
     };
 
     const fromAvatar = (
@@ -114,6 +114,7 @@ export const TransactionItem = ({ transaction, direction = "both" }: Transaction
                             )}
                             leadingIcon
                             coloring={direction !== "both"}
+                            compact
                             fw={600}
                             size="lg"
                         />

--- a/src/components/dashboard/SystemBalanceCard.tsx
+++ b/src/components/dashboard/SystemBalanceCard.tsx
@@ -37,6 +37,7 @@ export const SystemBalanceCard = ({ balance, difference }: SystemBalanceCardProp
                     <PAmount
                         value={toBranded<Copia>(BigInt(balance))}
                         leadingIcon
+                        compact
                         size="lg"
                         fw={700}
                     />

--- a/src/components/dashboard/SystemTotalCard.tsx
+++ b/src/components/dashboard/SystemTotalCard.tsx
@@ -36,6 +36,7 @@ export const SystemTotalCard = ({ total }: SystemTotalCardProps) => {
                     <PAmount
                         value={toBranded<Copia>(BigInt(total))}
                         leadingIcon
+                        compact
                         size="lg"
                         fw={700}
                     />

--- a/src/components/dashboard/UserBalanceCard.tsx
+++ b/src/components/dashboard/UserBalanceCard.tsx
@@ -38,6 +38,7 @@ export const UserBalanceCard = ({ balance, recentChange }: UserBalanceCardProps)
                     <PAmount
                         value={toBranded<Copia>(BigInt(balance))}
                         leadingIcon
+                        compact
                         size="lg"
                         fw={700}
                     />

--- a/src/components/ranking/RankingList.tsx
+++ b/src/components/ranking/RankingList.tsx
@@ -95,6 +95,7 @@ const RankingListItem = <T extends RankingEntity>({
                     {valueDisplay === "copia" ? (
                         <PAmount
                             coloring
+                            compact
                             leadingIcon
                             size="sm"
                             value={toBranded<Copia>(BigInt(entity.balance ?? 0))}
@@ -172,6 +173,7 @@ const RankingListItem = <T extends RankingEntity>({
                     {valueDisplay === "copia" ? (
                         <PAmount
                             coloring
+                            compact
                             leadingIcon
                             size="md"
                             value={toBranded<Copia>(BigInt(entity.balance ?? 0))}

--- a/src/components/ranking/RankingTop3.tsx
+++ b/src/components/ranking/RankingTop3.tsx
@@ -85,6 +85,7 @@ const RankingTop3Item = <T extends RankingEntity>({
                 {valueDisplay === "copia" ? (
                     <PAmount
                         coloring
+                        compact
                         fw={700}
                         leadingIcon
                         size={isFirst ? "lg" : "md"}

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -50,6 +50,7 @@ const UserProfileHeder = ({ name, balance }: { name: UserName; balance: Copia })
                         value={balance}
                         leadingIcon
                         coloring
+                        compact
                         size="custom"
                         customSize={2}
                     />


### PR DESCRIPTION
コンポーネントで実装済みの、コンパクト表示を適応しました。

<details>
<summary>画像:</summary>
<img width="2900" height="2022" alt="image" src="https://github.com/user-attachments/assets/ad11cb8b-e46a-4e60-9de1-f7c379ae4333" />
<img width="2986" height="610" alt="image" src="https://github.com/user-attachments/assets/9235be45-43cc-4e31-9d7d-2f8392bea1b4" />
<img width="2996" height="1434" alt="image" src="https://github.com/user-attachments/assets/e828122d-d2ee-4569-9da8-c4feab1487ad" />
<img width="2972" height="2036" alt="image" src="https://github.com/user-attachments/assets/ccbc7314-d9a8-45ba-921f-48d383d89337" />
<img width="2926" height="2018" alt="image" src="https://github.com/user-attachments/assets/ddcd6686-7a6c-4b40-adca-24cffa0ac094" />
</details>

---
Closes #130