### PR TITLE
feat: introduce 'safe' compact mode for PAmount component and update usage examples

### DIFF
--- a/src/components/PAmount.tsx
+++ b/src/components/PAmount.tsx
@@ -121,7 +121,7 @@ export const PAmount = <Size extends PAmountSize = undefined>(_props: PAmountPro
         leadingIcon = false,
         trailingDash = false,
         coloring = false,
-        compact = false,
+        compact = "safe",
         formatOptions,
         size,
         locales,

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -237,6 +237,7 @@ const CheckoutContent = ({
                     customSize={5}
                     leadingIcon
                     trailingDash
+                    compact="safe"
                 />
             </Center>
             {bill.description && (

--- a/src/pages/Sandbox.tsx
+++ b/src/pages/Sandbox.tsx
@@ -195,6 +195,110 @@ const PAmountSample = () => (
                             fw={500}
                             mb="xs"
                         >
+                            安全な省略表示 (compact=&quot;safe&quot;)
+                        </Text>
+                        <Text
+                            size="xs"
+                            c="dimmed"
+                            mb="xs"
+                        >
+                            キリの良い数字のみ省略（整数または小数1桁で割り切れる場合のみ）
+                        </Text>
+                        <Stack gap="xs">
+                            <Group>
+                                <Text
+                                    size="xs"
+                                    w={180}
+                                    c="dimmed"
+                                >
+                                    1,000,000 → 1M ✅
+                                </Text>
+                                <PAmount
+                                    value={toBranded<Copia>(1000000n)}
+                                    compact="safe"
+                                    leadingIcon
+                                />
+                            </Group>
+                            <Group>
+                                <Text
+                                    size="xs"
+                                    w={180}
+                                    c="dimmed"
+                                >
+                                    1,500,000 → 1.5M ✅
+                                </Text>
+                                <PAmount
+                                    value={toBranded<Copia>(1500000n)}
+                                    compact="safe"
+                                    leadingIcon
+                                />
+                            </Group>
+                            <Group>
+                                <Text
+                                    size="xs"
+                                    w={180}
+                                    c="dimmed"
+                                >
+                                    1,234,567 → そのまま
+                                </Text>
+                                <PAmount
+                                    value={toBranded<Copia>(1234567n)}
+                                    compact="safe"
+                                    leadingIcon
+                                />
+                            </Group>
+                            <Group>
+                                <Text
+                                    size="xs"
+                                    w={180}
+                                    c="dimmed"
+                                >
+                                    10,000 → 10K ✅
+                                </Text>
+                                <PAmount
+                                    value={toBranded<Copia>(10000n)}
+                                    compact="safe"
+                                    leadingIcon
+                                />
+                            </Group>
+                            <Group>
+                                <Text
+                                    size="xs"
+                                    w={180}
+                                    c="dimmed"
+                                >
+                                    12,345 → そのまま
+                                </Text>
+                                <PAmount
+                                    value={toBranded<Copia>(12345n)}
+                                    compact="safe"
+                                    leadingIcon
+                                />
+                            </Group>
+                            <Group>
+                                <Text
+                                    size="xs"
+                                    w={180}
+                                    c="dimmed"
+                                >
+                                    -2,000,000 → -2M ✅ (負数)
+                                </Text>
+                                <PAmount
+                                    value={toBranded<Copia>(-2000000n)}
+                                    compact="safe"
+                                    leadingIcon
+                                    coloring
+                                />
+                            </Group>
+                        </Stack>
+                    </div>
+
+                    <div>
+                        <Text
+                            size="sm"
+                            fw={500}
+                            mb="xs"
+                        >
                             スタイル・オプション
                         </Text>
                         <Stack gap="xs">


### PR DESCRIPTION
Checkout ページでの金額表示において、`compact={true}`では有効数字が少なすぎる問題を解決。
キリの良い数字のみを省略する`compact="safe"`モードを追加した。


<img width="890" height="1754" alt="image" src="https://github.com/user-attachments/assets/e45ba57a-0df1-406f-b7b7-02be0fdafe54" />

Closes #166